### PR TITLE
removed traling comma which causes "invalid json"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,6 @@
         "docs": "https://github.com/glueckpress/no-comment/blob/master/README.md"
     },
     "require": {
-        "php": ">=5.3",
+        "php": ">=5.3"
     }
 }


### PR DESCRIPTION
Fehlermeldung:

``` cli
Skipped branch master, "https://api.github.com/repos/glueckpress/no-comment/contents/composer.json?ref=9cd0a3b07f39453cbd9773ad4d59e54e48791c8a" does not contain valid JSON
Parse error on line 24:
..."php": ">=5.3",    }}
---------------------^
Expected: 'STRING' - It appears you have an extra trailing comma

 [Composer\Repository\InvalidRepositoryException]                             
  No valid composer.json was found in any branch or tag of git@github.com:glu  
  eckpress/no-comment.git, could not load a package from it.                   
```
